### PR TITLE
adjust vue cli package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ###
 quick setup
 ```
-npm install -g @vue/cli-service-global
+npm install -g @vue/cli
 
 npm install
 


### PR DESCRIPTION
I had to use `@vue/cli` to get vue to be recognised globally. If we do want `@vue/cli-service-global` perhaps reject this PR and add a note on adding the vue path to bash.